### PR TITLE
assign tz="" to zulu time strings

### DIFF
--- a/R/ic_date.R
+++ b/R/ic_date.R
@@ -17,9 +17,18 @@ ic_datetime <- function(x) {
   }
 
   plain <- gsub("[TZtz]", "", x)
-  datetime <- as.POSIXct(plain, format = "%Y%m%d%H%M%S")
+
+  # if time string has a trailing "Z" assign to zulu timezone  
+  if (any(grepl("Z$", x))) {
+    datetime <- as.POSIXct(plain, tz = "Zulu", format = "%Y%m%d%H%M%S")
+    attr(datetime, "tzone") <- ""  # change tz to "" which defaults to local system timezone; this could be left out if not desired 
+                                   # but as.POSIXct() uses tz = "" as standard argument and this is what is used below if not zulu time
+  } else {
+    datetime <- as.POSIXct(plain, format = "%Y%m%d%H%M%S")
+  }
   datetime
 }
+
 #' Convert ical date into R date
 #' @inheritParams ic_find
 #' @export


### PR DESCRIPTION
spent a bit of time seeing if I could sort out zulu timestrings being assigned to zulu time zone and then converted to local system time zone; came up with this to solve one of the other problems I was experiencing.

See what you think and if it should be included.