### PR TITLE
updated test-ic-extract to set tz=Europe/London for both the test and comparator datetime

### DIFF
--- a/tests/testthat/test-ic-extract.R
+++ b/tests/testthat/test-ic-extract.R
@@ -1,6 +1,12 @@
 context("test-ic-extract")
 
+# now that we are setting zulu time strings to zulu time in ic_date() to test against a specific 
+# time zone datetime we need to set it first
 test_that("ic_extract works", {
-  expect_equal(ic_extract(ical_example, "DTSTART"),
-               as.POSIXct("2018-08-09 16:00:00 BST"))
+  test_datetime <- ic_extract(ical_example, "DTSTART")
+  attr(test_datetime, "tzone") <- "Europe/London"
+  expect_equal(test_datetime,
+               as.POSIXct("2018-08-09 17:00:00", tz = "Europe/London"))
 })
+
+


### PR DESCRIPTION
I think setting the both the test date and the comparator date to same time zone should fix this particular issue and be robust against the CRAN servers using different time zones as their local time.