### PR TITLE
Issue https://github.com/ATFutures/calendar/issues/55 fix :wrench:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ inst/doc
 .Rhistory
 .RData
 docs
+sandbox/

--- a/R/ic_dataframe.R
+++ b/R/ic_dataframe.R
@@ -17,30 +17,53 @@
 #' identical(x, x_df2)
 ic_dataframe <- function(x) {
 
-  if(methods::is(object = x, class2 = "data.frame")) {
+  if (methods::is(object = x, class2 = "data.frame")) {
+
     return(x)
+
   }
 
   stopifnot(methods::is(object = x, class2 = "character") | methods::is(object = x, class2 = "list"))
 
-  if(methods::is(object = x, class2 = "character")) {
+  if (methods::is(object = x, class2 = "character")) {
+
     x_list <- ic_list(x)
-  } else if(methods::is(object = x, class2 = "list")) {
+
+  } else {
+
     x_list <- x
+
   }
 
-  x_list_named <- lapply(x_list, function(x) {
-    ic_vector(x)
-  })
+  x_list_named <- lapply(
+    X = x_list,
+    FUN = function(x) {
+      ic_vector(x)
+    }
+  )
+
   x_df <- ic_bind_list(x_list_named)
 
   date_cols <- grepl(pattern = "VALUE=DATE", x = names(x_df))
-  if(any(date_cols)) {
-    x_df[date_cols] <- lapply(x_df[, date_cols], ic_date)
+
+  if (any(date_cols)) {
+
+    x_df[date_cols] <- lapply(
+      X   = x_df[date_cols],
+      FUN = ic_date
+    )
+
   }
+
   datetime_cols <- names(x_df) %in% c("DTSTART", "DTEND")
-  if(any(datetime_cols)) {
-    x_df[datetime_cols] <- lapply(x_df[, datetime_cols], ic_datetime)
+
+  if (any(datetime_cols)) {
+
+    x_df[datetime_cols] <- lapply(
+      X   = x_df[datetime_cols],
+      FUN = ic_datetime
+    )
+
   }
 
   # names(x_df) <- gsub(pattern = ".VALUE.DATE", replacement = "", names(x_df))


### PR DESCRIPTION
Hi,

I took the liberty to give the code a bit of air, and more explicit usage of arguments in the `lapply()`-functions. I hope this is OK.

This PR closes https://github.com/ATFutures/calendar/issues/55 

--------

**Commit Message**

* Issue Fix: If "VALUE=DATE", "DTSTART" or "DTEND" exists in the ical-object the dates are now parsed correctly using data.frames instead of lists.

* Minor Fix: Removed redundant if-statement. `ic_dataframe()`-function already checks wether the object is a `character` or `list` and therefore the if-statement is redundant.

* Layout Fix: Increased spacing between if-statement and conditions, and added vertical space. All `lapply`-functions are now more verbose in the function calls.